### PR TITLE
Update creating template

### DIFF
--- a/documentation/sdk/create-leo-app/00_app_installation.md
+++ b/documentation/sdk/create-leo-app/00_app_installation.md
@@ -16,7 +16,7 @@ sidebar_label: Installation
 With NPM:
 
 ```bash
-npm create aleo-app@latest
+npm create leo-app@latest
 ```
 
 1. Enter the project name.


### PR DESCRIPTION
The create-aleo-app contains deprecated functions, such as executeOffline: [create aleo-app](https://www.npmjs.com/package/create-aleo-app.)

Meanwhile, create-leo-app is the correct version for creating a template app: [create leo-app](https://www.npmjs.com/package/create-leo-app)

Both are maintained by the Provable team