### PR TITLE
Update list of commands for add, deploy, and removed red text

### DIFF
--- a/documentation/leo/05_commands.md
+++ b/documentation/leo/05_commands.md
@@ -27,6 +27,8 @@ You can print the list of commands by running `leo --help`
 * [`build`](#leo-build) - Compile the current package as a program.
 * [`run`](#leo-run) - Run a program with input variables.
 * [`execute`](#leo-execute) - Execute a program with input variables.
+* [`add`](#leo-add) - Add a new on-chain or local dependency to the current package.
+* [`deploy`](#leo-deploy) - Deploy a program.
 * [`clean`](#leo-clean) - Clean the output directory.
 * [`update`](#leo-update) - Update to the latest version of Leo.
 * [`account`](#leo-account) - Create a new Aleo account.
@@ -37,7 +39,7 @@ You can print the list of commands by running `leo --help`
 ## `leo example`
 
 To list all available example programs, run:
-```bash
+```
 leo example
 
 # Output:
@@ -252,7 +254,7 @@ leo account new --write
 
 To list all options
 
-```bash
+```
 leo account --help
 
 # Output:


### PR DESCRIPTION
Update:
1. Add
2. Deploy
3. Removed red text for `in` and `for`