### PR TITLE
Constant example added to example program

### DIFF
--- a/documentation/leo/03_language.md
+++ b/documentation/leo/03_language.md
@@ -156,6 +156,7 @@ The body of the program is delimited by curly braces `{}`.
 import foo.aleo;
 
 program hello.aleo {
+    const FOO: u64 = 1u64;
     mapping balances: address => u64;
 
     record token {
@@ -187,7 +188,7 @@ program hello.aleo {
    }
 
     function compute(a: u64, b: u64) -> u64 {
-        return a + b;
+        return a + b + FOO;
     }
 }
 ```


### PR DESCRIPTION
const example is added and named as "FOO" like stated in the rest of the docs. The visual is not the best, but the reader will easily understand that FOO is not the input to a function, but a constant which is defined at the beginning.
