### PR TITLE
Update basic bank spelling and copy

### DIFF
--- a/documentation/leo/10_basic_bank.md
+++ b/documentation/leo/10_basic_bank.md
@@ -12,17 +12,19 @@ This program implements a bank that issues tokens to users and allows users to d
 2. A user deposits tokens via the `deposit` function.
 3. Upon a user's request to withdraw, the bank calculates the appropriate amount of compound interest and pays the user the principal and interest via the `withdraw` function.
 
-Note that the program can be easily extended to include addition features such as a `transfer` function, which would allow users to transfer tokens to other users.
+Note that the program can be easily extended to include additional features such as a `transfer` function, which would allow users to transfer tokens to other users.
 
 ## Bugs
 
 You may have already guessed that this program has a few bugs. We list some of them below: 
 - `withdraw` can only be invoked by the bank. A malicious bank could lock users' tokens by not invoking `withdraw`.
 - `withdraw` fails if the sum of the interest and principal is greater than the user's balance. 
-- User's can increase their principal by depositing tokens multiple times, including immediately before withdrawl.
+- Users can increase their principal by depositing tokens multiple times, including immediately before withdrawal.
 - Integer division rounds down; if the calculated interest is too small, then it will be rounded down to zero.
 
 Can you find any others?
+
+There are, of course, ways to write a version of this application without these bugs. This could be a good exercise for the reader.
 
 ## Language Features and Concepts
 - `record` declarations


### PR DESCRIPTION
Update:
1. Additional
2. Update copy
3. Spelling errors for users and withdrawal