### PR TITLE
Update shl

### DIFF
--- a/documentation/leo/04_operators.md
+++ b/documentation/leo/04_operators.md
@@ -1041,7 +1041,7 @@ let b: u8 = a.shl(1u8); // 4u8
 
 #### Description
 
-Shifts `first` left by `second` bits, storing the result in `destination`.
+Shifts `first` left by `second` bits, storing the result in `destination`. The operation halts if the shift distance exceeds the bit size of `first`, or if the shifted result does not fit within the type of `first`.
 
 #### Supported Types
 


### PR DESCRIPTION
Added statement:
The operation halts if the shift distance exceeds the bit size of `first`, or if the shifted result does not fit within the type of `first`