### PR TITLE
Updated square_root

### DIFF
--- a/documentation/leo/04_operators.md
+++ b/documentation/leo/04_operators.md
@@ -1181,7 +1181,7 @@ let a: field = 1field.square_root(); // 1field
 
 #### Description
 
-Computes the square root of the input, storing the result in `destination`.
+Computes the square root of the input, storing the result in `destination`. If the input is a quadratic residue, the function returns the `smaller` of the two possible roots based on modular ordering. If the input is not a quadratic residue, execution halts.
 
 #### Supported Types
 


### PR DESCRIPTION
Explanation added. After testing with non-square numbers, I observed that the operation does not always halt. Instead, execution halts only if the input is not a quadratic residue in the prime field