### PR TITLE
Remove reference to `create aleo-app` in Leo lang documentation

### DIFF
--- a/documentation/sdk/create-leo-app/00_app_installation.md
+++ b/documentation/sdk/create-leo-app/00_app_installation.md
@@ -16,7 +16,7 @@ sidebar_label: Installation
 With NPM:
 
 ```bash
-npm create aleo-app@latest
+npm create leo-app@latest
 ```
 
 1. Enter the project name.
@@ -27,7 +27,7 @@ npm create aleo-app@latest
 
 3. If you choose `React` as your framework, the supported templates are:
     - `JavaScript` + `Leo`
-    - `TypeScript` + `Leo`
+    - `TypeScript` + `React`
     - `TypeScript` + `Next.js`
 
 ## More Information


### PR DESCRIPTION
This PR replaces a reference to `create aleo-app` with the correct command:  `create leo-app` in the online documentation.