### PR TITLE
Update Record and Struct names to use CamelCase format

### DIFF
--- a/documentation/language/02_structure.md
+++ b/documentation/language/02_structure.md
@@ -25,12 +25,12 @@ program hello.aleo {
     const FOO: u64 = 1u64;
     mapping account: address => u64;
 
-    record token {
+    record Token {
         owner: address,
         amount: u64,
     }
 
-    struct message {
+    struct Message {
         sender: address,
         object: u64,
     }
@@ -38,8 +38,8 @@ program hello.aleo {
     async transition mint_public(
         public receiver: address,
         public amount: u64,
-    ) -> (token, Future) {
-        return (token {
+    ) -> (Token, Future) {
+        return (Token {
             owner: receiver,
             amount,
         }, update_state(receiver, amount));
@@ -158,7 +158,7 @@ When passing a record as input to a program function, the `_nonce: group` compon
 (but it does not need to be declared in the Leo program).
 
 ```aleo showLineNumbers
-record token {
+record Token {
     // The token owner.
     owner: address,
     // The token amount.

--- a/documentation/language/02_structure.md
+++ b/documentation/language/02_structure.md
@@ -138,7 +138,7 @@ A struct data type is declared as `struct {name} {}`.
 Structs contain component declarations `{name}: {type},`.
 
 ```leo showLineNumbers
-struct array3 {
+struct Array3 {
     a0: u32,
     a1: u32,
     a2: u32,

--- a/documentation/language/03_data_types.md
+++ b/documentation/language/03_data_types.md
@@ -138,25 +138,25 @@ let arr: [bool; 4] = [true, false, true, false];
 // Nested array
 let nested: [[bool; 2]; 2] = [[true, false], [true, false]];
 
-struct bar {
+struct Bar {
     data: u8,
 }
 
 // Array of structs
-let arr_of_structs: [bar; 2] = [bar { data: 1u8 }, bar { data: 2u8 }];
+let arr_of_structs: [Bar; 2] = [Bar { data: 1u8 }, Bar { data: 2u8 }];
 
 // Access the field of a struct within an array
-transition foo(a: [bar; 8]) -> u8 {
+transition foo(a: [Bar; 8]) -> u8 {
     return a[0u8].data;
 }
 
 // Struct that contains an array
-struct bat {
+struct Bat {
     data: [u8; 8],
 }
 
 // Record that contains an array
-record floo {
+record Floo {
     owner: address,
     data: [u8; 8],
 }

--- a/documentation/language/08_cheatsheet.md
+++ b/documentation/language/08_cheatsheet.md
@@ -76,7 +76,7 @@ You can cast an `address` to a `field` but not vice versa.
 ## 4. Records
 Defining a `record`
 ```leo
-record token {
+record Token {
     owner: address,
     amount: u64,
 }
@@ -99,7 +99,7 @@ let user_balance: u64 = user.balance;
 ## 5. Structs
 Defining a `struct`
 ```leo
-struct message {
+struct Message {
     sender: address,
     object: u64,
 };
@@ -174,7 +174,7 @@ let third: field = t.2;
 transition mint_public(
     public receiver: address,
     public amount: u64,
-) -> token { /* Your code here */ }
+) -> Token { /* Your code here */ }
 ```
 
 ## 9. Functions


### PR DESCRIPTION
This PR updates the names of Records and Structs in the language guide to use CamelCase naming conventions.