### PR TITLE
Leo dependency guide

### DIFF
--- a/documentation/cli/04_dependencies.md
+++ b/documentation/cli/04_dependencies.md
@@ -57,4 +57,20 @@ When deploying to a local devnet, specify the path for the local dependency as f
 ```
 leo add program_name.aleo --local ./path_to_dependency
 ```
-
+The dependencies section in the `program.json` manifest should include the path:
+```json
+{
+  "program": "your_program.aleo",
+  "version": "0.0.0",
+  "description": "",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "local_dependency.aleo",
+      "location": "local",
+      "network": null,
+      "path": "./path"
+    }
+  ]
+} 
+```

--- a/documentation/cli/04_dependencies.md
+++ b/documentation/cli/04_dependencies.md
@@ -76,4 +76,8 @@ The dependencies section in the `program.json` manifest should include the path:
 ```
 
 ## Deploying to a program with local dependencies to a network.
-When deploying a program that uses local dependcies, each of those dependencies will be deployed in order, followed by the main program.  Those dependencies should be specified as local dependencies in the `program.json` manifest.
+When deploying a program that uses local dependcies, use the following command:
+```bash
+leo deploy --recursive
+```
+All local dependency will be deployed in order, followed by the main program.  Deployed dependencies will be skipped.

--- a/documentation/cli/04_dependencies.md
+++ b/documentation/cli/04_dependencies.md
@@ -13,7 +13,7 @@ program test.aleo {
 }
 ```
 
-Use the `leo add` command to update the `program.json` manifest to include any dependencies used in your program.
+From the root of your Leo program directory, use the `leo add` command to update the `program.json` manifest to add dependencies.
 
 ## Deployed Programs
 When adding a deployed program as a dependency to your program, such as the `credits.aleo`, use the following command::
@@ -74,3 +74,6 @@ The dependencies section in the `program.json` manifest should include the path:
   ]
 } 
 ```
+
+## Deploying to a program with local dependencies to a network.
+When deploying a program that uses local dependcies, each of those dependencies will be deployed in order, followed by the main program.  Those dependencies should be specified as local dependencies in the `program.json` manifest.

--- a/documentation/cli/04_dependencies.md
+++ b/documentation/cli/04_dependencies.md
@@ -3,6 +3,58 @@ id: dependencies
 title: Dependency Management
 sidebar_label: Dependency Management
 ---
-<!--TODO:-->
+## Leo imports
+In your `main.leo` file, specify any imported dependencies using the `import` keyword before the program declaration:
+```leo
+import credits.aleo;
 
-Coming soon!
+program test.aleo {
+...
+}
+```
+
+Use the `leo add` command to update the `program.json` manifest to include any dependencies used in your program.
+
+## Deployed Programs
+When adding a deployed program as a dependency to your program, such as the `credits.aleo`, use the following command::
+
+```
+leo add credits.aleo
+```
+or
+```
+leo add credits
+```
+
+If you are deplolying to mainnet, you will need to specify mainnet imports using the `--network` flag as follows:
+
+```
+leo add credits --network mainnet
+```
+
+For the first imported dependency, a new `dependencies` field will be added to the 'package.json` manifest:
+
+```json
+{
+  "program": "your_program.aleo",
+  "version": "0.0.0",
+  "description": "",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "credits.aleo",
+      "location": "network",
+      "network": "testnet",
+      "path": null
+    }
+  ]
+}
+```
+
+## Local development
+When deploying to a local devnet, specify the path for the local dependency as follows:
+
+```
+leo add program_name.aleo --local ./path_to_dependency
+```
+


### PR DESCRIPTION
This PR adds content to the Leo documentation instructing users how to add dependencies using the Leo CLI.