### PR TITLE
Fixing spelling errors

### DIFF
--- a/documentation/02_where.md
+++ b/documentation/02_where.md
@@ -4,7 +4,7 @@ title: Where to go?
 sidebar_label: Where to go?
 ---
 
-While a deep dive through the Leo documentation is a useful exercise, we realize that it may not be very pratical. To help you along your journey, we've provided a "map" to help you find your way.
+While a deep dive through the Leo documentation is a useful exercise, we realize that it may not be very practical. To help you along your journey, we've provided a "map" to help you find your way.
 
 ## Roadmap
 

--- a/documentation/cli/00_overview.md
+++ b/documentation/cli/00_overview.md
@@ -4,7 +4,7 @@ title: The Leo Command Line Interface
 sidebar_label: Overview 
 ---
 
-The Leo CLI is a command line interface tool that comes equipped with the Leo compiler. It contains a number of helpful 
+The Leo CLI is a command line interface tool that comes equipped with the Leo compiler.
 
 :::tip
 You can print the list of commands by running `leo --help`
@@ -15,7 +15,7 @@ You can print the list of commands by running `leo --help`
 * [`account`](#leo-account) - Create a new Aleo account, sign and verify messages.
 * [`new`](#leo-new) - Create a new Leo project in a new directory.
 * [`build`](#leo-build) - Compile the current project.
-* [`deploy`](#leo-deploy) - Generate proving and verifying keys and produce a transaction contianing the deployment.
+* [`deploy`](#leo-deploy) - Generate proving and verifying keys and produce a transaction containing the deployment.
 * [`run`](#leo-run) - Run a program without producing a proof.
 * [`execute`](#leo-execute) - Execute a program and produce a transaction containing a proof.
 * [`debug`](#leo-debug) - Run the interactive debugger in the current package.
@@ -58,7 +58,7 @@ To create a new account and save it to your `.env` file, run:
 leo account new --write
 ````
 
-`leo account` has a number of additional subomcommands. To list all options, run:
+`leo account` has a number of additional subcommands. To list all options, run:
 
 ```
 leo account --help
@@ -79,7 +79,7 @@ Options:
   -d                 Print additional information for debugging
   -q                 Suppress CLI output
       --path <PATH>  Optional path to Leo program root folder
-      --home <HOME>  Optional path to aleo program registry.
+      --home <HOME>  Optional path to Aleo program registry.
   -h, --help         Print help
 ```
 
@@ -242,7 +242,7 @@ Options:
   -n, --network <NETWORK>    Network to use. Defaults to entry in `.env`.
   -q                         Suppress CLI output
       --path <PATH>          Path to Leo program root folder
-      --home <HOME>          Path to aleo program registry
+      --home <HOME>          Path to Aleo program registry
   -h, --help                 Print help
 ```
 

--- a/documentation/getting_started/03_hello.md
+++ b/documentation/getting_started/03_hello.md
@@ -31,7 +31,7 @@ Now let's compile the program.
 leo build
 ```
  
-On invoking the build command, Leo automatically creates a `/build⁠` and `output/`⁠ folder in the project directory. The compiled code is contained in the `build` directory. `output` is used to stored intermediate artificats from compilation. 
+On invoking the build command, Leo automatically creates a `/build⁠` and `output/`⁠ folder in the project directory. The compiled code is contained in the `build` directory. `output` is used to stored intermediate artifacts from compilation. 
 
 
 The `leo run` command will compile and run the program.

--- a/documentation/language/06_programs.md
+++ b/documentation/language/06_programs.md
@@ -216,7 +216,7 @@ snarkVM imposes the following limits on Aleo programs:
 
 
 Some other protocol-level limits to be aware of are:
-- **the maximum transaction size is 128 KB.** If your program execeeds this, perhaps by requiring large inputs or producing large outputs, consider optimizing the data types in your Leo code.
+- **the maximum transaction size is 128 KB.** If your program exceeds this, perhaps by requiring large inputs or producing large outputs, consider optimizing the data types in your Leo code.
 - **the maxmimum number of micro-credits your transaction can consume for on-chain execution is `100_000_000`.**. If your program exceeds this, consider optimizing on-chain components of your Leo code.
 
 As with the above restructions. these limits can only be increased via the governance process.
@@ -247,6 +247,6 @@ Observe that both branches of the conditional are executed in the transition. Th
 
 On-chain commands are not all purely functional; for example, `get`, `get.or_use`, `contains`, `remove`, and `set`, whose semantics all depend on the state of the program. As a result, the same technique for off-chain code cannot be used. Instead, the on-chain code is compiled using `branch` and `position` commands, which allow the program to define sequences of code that are skipped. However, because destination registers in skipped instructions are not initialized, they cannot be accessed in a following instructions. In other words, depending on the branch taken, some registers are invalid and an attempt to access them will return in an execution error. The only Leo code pattern that produces such an access attempt is code that attempts to assign out to a parent scope from a conditional statement; consequently, they are disallowed.
 
-This restriction can be mitigated by future improvements to `snarkVM`, however we table that discusstion for later.
+This restriction can be mitigated by future improvements to `snarkVM`, however we table that discussion for later.
 
 [^1]: There are some operations that are not purely functional, e.g `add` which can fail on overflow.

--- a/documentation/leo_by_example/04_token.md
+++ b/documentation/leo_by_example/04_token.md
@@ -118,7 +118,7 @@ Output
 }
 ```
 
-Again, we see the arguments used for the finzalize function of `transfer_public` - Alice's address, Bob's address, and the amount to transfer. The public mapping will be queryable on-chain.
+Again, we see the arguments used for the finalize function of `transfer_public` - Alice's address, Bob's address, and the amount to transfer. The public mapping will be queryable on-chain.
 
 ## <a id="step3"></a> Private Transfer
 

--- a/documentation/resources/03_projects.md
+++ b/documentation/resources/03_projects.md
@@ -9,4 +9,4 @@ sidebar_label: Built on Leo
 Coming soon!
 
 **Please fill out [this](https://forms.gle/6bt7a65hFBV9MpqN6) form if you're building on Leo.
-The Leo team will ensure that submitted projects retain backwards compatibility and recieve developer support.**
+The Leo team will ensure that submitted projects retain backwards compatibility and receive developer support.**

--- a/documentation/testing/00_overview.md
+++ b/documentation/testing/00_overview.md
@@ -23,4 +23,4 @@ At some point you'll need testnet credits. There are a few community-supported f
 
 - [**Sotertech**](https://faucetbeta.sotertech.io/) - 10 credits /  24 hours (*quickest to access as of 2/17/25*)
 
-The faucets are periodically refereshed.
+The faucets are periodically refreshed.

--- a/documentation/testing/02_debugger.md
+++ b/documentation/testing/02_debugger.md
@@ -12,7 +12,7 @@ Leo ships with an interactive debugger that you can use to step through your pro
 
 ### Getting Started
 
-Run through the [tutorial](./../guides/02_debuggin.md) to get familiar with the debubugger. 
+Run through the [tutorial](./../guides/02_debuggin.md) to get familiar with the debugger. 
 
 ### Cheatsheet
 


### PR DESCRIPTION
This PR fixed typos in various spots in the repo.  I ran a spellchecker across all the md files.