### PR TITLE
Added comment in Leo execute overview  for broadcast flag

### DIFF
--- a/documentation/cli/00_overview.md
+++ b/documentation/cli/00_overview.md
@@ -197,6 +197,8 @@ This command synthesizes the program circuit and generates proving and verifying
  Leo ✅ Executed 'hello.aleo/main' (in "/hello/build")
 ```
 
+Use the `-b` or `--broadcast` flag to broadcast a transaction to a network.
+
 See [Execute](./02_executing.md) for more details.
 
 

--- a/documentation/cli/00_overview.md
+++ b/documentation/cli/00_overview.md
@@ -197,7 +197,9 @@ This command synthesizes the program circuit and generates proving and verifying
  Leo ✅ Executed 'hello.aleo/main' (in "/hello/build")
 ```
 
-Use the `-b` or `--broadcast` flag to broadcast a transaction to a network.
+:::info
+The `-b` or `--broadcast` flag is required in order to broadcast a transaction to a network.
+:::
 
 See [Execute](./02_executing.md) for more details.
 

--- a/documentation/cli/01_deploying.md
+++ b/documentation/cli/01_deploying.md
@@ -20,7 +20,7 @@ From the root of the Leo program directory, run the following command:
 leo deploy
 ```
 
-Alternatively, the command syntax accomodates enviroment variables:
+Alternatively, the command syntax accommodates environment variables:
 ```bash
 leo deploy --endpoint "{ENDPOINT} --private-key "{$PRIVATE_KEY}"
 ```


### PR DESCRIPTION
This PR includes an instruction in the in the Leo CLI overview section to inform users that using the broadcast flag (`-b` or `--broadcast`) is required in order to submit a transaction to a network.