### PR TITLE
Fixing typos and syntax

### DIFF
--- a/documentation/getting_started/02_ide.md
+++ b/documentation/getting_started/02_ide.md
@@ -4,7 +4,7 @@ title: Your Development Environment
 sidebar_label: Dev Env
 ---
 
-Developers can choose from a wide variety of development environment. 
+Developers can choose from a wide variety of development environments. 
 
 ## Leo Playground
 

--- a/documentation/getting_started/02_ide.md
+++ b/documentation/getting_started/02_ide.md
@@ -4,7 +4,7 @@ title: Your Development Environment
 sidebar_label: Dev Env
 ---
 
-Developers can choose from a wide variety of development environment. Each 
+Developers can choose from a wide variety of development environment. 
 
 ## Leo Playground
 

--- a/documentation/getting_started/03_hello.md
+++ b/documentation/getting_started/03_hello.md
@@ -71,15 +71,9 @@ Let's go through the project.
 }
 ```
 
-The program ID in `program` is the official name that other developers will be able to look up after you have published your program.
+The program ID in `program` is the official name that other developers will be able to look up after the program has been deployed to a network.
 ```json
     "program": "hello.aleo",
-```
-
-All files in the current package will be compiled with the specified Leo `version`.
-
-```json
-    "version": "0.0.0",
 ```
 
 Dependencies will be added to the field of the same name, as they are added. The dependencies are also pegged in the **leo.lock** file.

--- a/documentation/language/01_layout.md
+++ b/documentation/language/01_layout.md
@@ -22,10 +22,4 @@ The program ID in `program` is the official name that other developers will be a
     "program": "hello.aleo",
 ```
 
-All files in the current package will be compiled with the specified Leo `version`.
-
-```json
-    "version": "0.0.0",
-```
-
 Dependencies will be added to the field of the same name, as they are added. The dependencies are also pegged in the **leo.lock** file.

--- a/documentation/testing/03_devnet.md
+++ b/documentation/testing/03_devnet.md
@@ -8,9 +8,8 @@ A local devnet can be a heavyweight but reliable way to test your application on
 
 ## Setup
 
-To run a local devnet, you'll need to install [snarkOS](https://developer.aleo.org/guides/introduction/getting_started#2-installing-snarkos).  
-Be sure to use the latest [release](https://github.com/ProvableHQ/snarkOS/releases).
-You'll also need `tmux` (instructions below) and the [devnet.sh](https://github.com/ProvableHQ/snarkOS/blob/staging/devnet.sh) script in the `snarkOS` repository.
+To run a local devnet using SnarkOS, you'll need to install the latest [SnarkOS release](https://github.com/ProvableHQ/snarkOS/releases).
+You'll also need `tmux` (instructions below) and the [devnet.sh](https://github.com/ProvableHQ/snarkOS/blob/staging/devnet.sh) script from the [SnarkOS repository](https://github.com/ProvableHQ/snarkOS).
 
 <details><summary>macOS</summary>
 
@@ -126,7 +125,7 @@ You can use the SnarkOS CLI to view your Records using the following command syn
 snarkos developer scan --endpoint http://localhost:3030 --private-key APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH --start <block_number> --network 1
 ```
 
-Setting `block_number` to `0` will list all of the records from genesis, including your test credit records. 
+Setting `block_number` to `0` will list all of the records created starting from the genesis block, including your test credit records. 
 
 ```bash
 ⚠️  Attention - Scanning the entire chain. This may take a while...

--- a/documentation/testing/03_devnet.md
+++ b/documentation/testing/03_devnet.md
@@ -8,8 +8,8 @@ A local devnet can be a heavyweight but reliable way to test your application on
 
 ## Setup
 
-To run a local devnet using SnarkOS, you'll need to install the latest [SnarkOS release](https://github.com/ProvableHQ/snarkOS/releases).
-You'll also need `tmux` (instructions below) and the [devnet.sh](https://github.com/ProvableHQ/snarkOS/blob/staging/devnet.sh) script from the [SnarkOS repository](https://github.com/ProvableHQ/snarkOS).
+To run a local devnet using snarkOS, you'll need to install the latest [snarkOS release](https://github.com/ProvableHQ/snarkOS/releases).
+You'll also need `tmux` (instructions below) and the [devnet.sh](https://github.com/ProvableHQ/snarkOS/blob/staging/devnet.sh) script from the [snarkOS repository](https://github.com/ProvableHQ/snarkOS).
 
 <details><summary>macOS</summary>
 


### PR DESCRIPTION
This PR fixes a couple minor typos and changes some syntax to improve readability. 

I have also removed two comments stating that the version field in the `program.json` manifest refers to the Leo version used in the project.  Changing the version in this field does not affect compilation.  While it's not ideal to lack documentation regarding the purpose of this field, it is preferable to omit information than to confuse developers 