### PR TITLE
Content for native testing framework section of the Leo-lang docs

### DIFF
--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -76,7 +76,7 @@ Each test file is required to have at least one transition function.
 
 
 ## Using interpreted tests for modelling on-chain state
-While the testing framework cannot access on-chain state from either Testnet or Mainnet, developers can simulate on-chain state using interpreted tests.  Developers are able to await Futures and update mappings using interpreted tests.  When using interpreted tests, the `transition` or `function` keyword is replaced with the `script` keyword.
+While the testing framework cannot access on-chain state from either `testnet` or `mainnet`, developers can simulate on-chain state using interpreted tests. Developers are able to await `Future`s and update mappings using interpreted tests. When using interpreted tests, the `transition` or `function` keyword is replaced with the `script` keyword.
 
 ```Leo
 @test

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -69,6 +69,9 @@ transition test_record_maker() {
     }
 ```
 
+:::info
+Each test file is required to have at least one transition function.
+:::
 
 
 ## Using interpreted tests for modelling on-chain state
@@ -94,11 +97,9 @@ script test_async() {
 While non-async logic may be tested using an interpreted tests, all async functionality must be tested within interpreted tests.
 :::
 
+
 ## Running tests
-Invoking the `leo test` command will run all of the compiled and interpreted tests. Developer may optionally select individual tests by supplying the function test name to the `leo test` command.
-
-
-
-
-Need at least one transition function in the test file.
-
+Invoking the `leo test` command will run all of the compiled and interpreted tests. Developer may optionally select individual tests by supplying the function test name as follows:
+```bash
+leo test test_async
+```

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -8,6 +8,7 @@ sidebar_label: Testing
 The Leo testing frameworks enables developers to validate their Leo program logic by writing unit and integration tests. Tests are written in Leo and are located in a `/tests` subdirectory of the main Leo project directory.
 
 ```bash
+example_program
 ├── build
 │   ├── imports
 │   │   └── test_example_program.aleo
@@ -20,7 +21,7 @@ The Leo testing frameworks enables developers to validate their Leo program logi
 │   └── test_example_program.leo
 └── program.json
 ```
-The test file is a Leo program that imports the program in `main.leo`.  The test functions will all be annotated with `@test` above the the function declaration. 
+The test file is a Leo program that imports the program in `main.leo`.  The test functions will all be annotated with `@test` above the function declaration. 
 
 This tutorial will use an example program which can be found in the [example's repository](https://github.com/ProvableHQ/leo-examples/tree/main/tests).  
 
@@ -31,7 +32,7 @@ Developers can add multiple `leo` files to the test directory but must ensure th
 
 ## Testing transition function logic.
 
-The `example_program.leo` program contains a transition function which returns the sum of two `u32` inputs.  When testing 
+The `example_program.leo` program contains a transition function which returns the sum of two `u32` inputs.
 
 ```Leo
 transition simple_addition(public a: u32, b: u32) -> u32 {
@@ -40,7 +41,7 @@ transition simple_addition(public a: u32, b: u32) -> u32 {
 }
 ```
 
-In the `test_example_program.leo`, we can write two tests to ensure that the transition logic returns correct values.
+The `test_example_program.leo` contains two tests to ensure that the transition logic returns a correct output and fails when the output does not match the sum of the input values.
 ```Leo
 @test
 transition test_simple_addition() {
@@ -75,18 +76,16 @@ Each test file is required to have at least one transition function.
 
 
 ## Using interpreted tests for modelling on-chain state
-While the testing framework cannot access on-chain state from Testnet or Mainnet, developers can simulate on-chain state using interpreted tests.  Within interpreted tests, developers are able to await Futures and update mappings.  Interpreted tests are annotated with the `script` keyword.
+While the testing framework cannot access on-chain state from either Testnet or Mainnet, developers can simulate on-chain state using interpreted tests.  Developers are able to await Futures and update mappings using interpreted tests.  When using interpreted tests, the `transition` or `function` keyword is replaced with the `script` keyword.
 
 ```Leo
 @test
 script test_async() {
     const VAL: field = 12field;
     let fut: Future = example_program.aleo/set_mapping(VAL);
-    // We must await this future for the async code to run.
     fut.await();
     assert_eq(Mapping::get(example_program.aleo/map, 0field), VAL);
 
-    // scripts can also do other things normally only async code can do:
     let rand_val: field = ChaCha::rand_field();
     Mapping::set(example_program.aleo/map, VAL, rand_val);
     let value: field = Mapping::get(example_program.aleo/map, VAL);

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -99,7 +99,16 @@ External transitions -- async or not -- may be called from native or interpreted
 
 
 ## Running tests
-Invoking the `leo test` command will run all of the compiled and interpreted tests. Developer may optionally select individual tests by supplying the function test name as follows:
+Invoking the `leo test` command will run all of the compiled and interpreted tests. Developer may optionally select an individual tests by supplying a a test function name or a string that is contained within a test function name.  For instance, to run the test for `test_async`, developers would use the following command:
 ```bash
 leo test test_async
 ```
+Either of the following commands will run both of the addition function tests:
+```bash
+leo test simple
+```
+or
+```bash
+leo test addition
+```
+

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -23,7 +23,7 @@ example_program
 ```
 The test file is a Leo program that imports the program in `main.leo`.  The test functions will all be annotated with `@test` above the function declaration. 
 
-This tutorial will use an example program which can be found in the [example's repository](https://github.com/ProvableHQ/leo-examples/tree/main/tests).  
+This tutorial will use an example program which can be found in the [example's repository](https://github.com/ProvableHQ/leo-examples/tree/main/example_with_test).  
 
 :::info
 Developers can add multiple `leo` files to the test directory but must ensure that the name of the test file matches the test program name.  For example, if the name of the test file is `test_example_program.leo`, the test program name must be `test_example_program.aleo`.

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -26,7 +26,7 @@ The test file is a Leo program that imports the program in `main.leo`.  The test
 This tutorial will use an example program which can be found in the [example's repository](https://github.com/ProvableHQ/leo-examples/tree/main/tests).  
 
 :::info
-Developers can add multiple `leo` files to the test directory but must ensure that the name of the test file matches the program name.  For example, if the name of the test file is `test_example_program.leo`, the program name must be `test_example_program.aleo`.
+Developers can add multiple `leo` files to the test directory but must ensure that the name of the test file matches the test program name.  For example, if the name of the test file is `test_example_program.leo`, the test program name must be `test_example_program.aleo`.
 :::
 
 

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -25,7 +25,7 @@ The test file is a Leo program that imports the program in `main.leo`.  The test
 This tutorial will use an example program which can be found in the [example's repository](https://github.com/ProvableHQ/leo-examples/tree/main/tests).  
 
 :::info
-The name of the test file must match the program name.  For example, if the name of the test file is `test_example_program.leo`, the program name should be `test_example_program.aleo`.
+Developers can add multiple `leo` files to the test directory but must ensure that the name of the test file matches the program name.  For example, if the name of the test file is `test_example_program.leo`, the program name must be `test_example_program.aleo`.
 :::
 
 
@@ -59,6 +59,18 @@ The `@should_fail` annotation should be added after the `@test` annotation for t
     }
 ```
 
+Developers can test that Record and struct fields match their expected values.
+
+```Leo
+@test
+transition test_record_maker() {
+        let r: example_program.aleo/Example = example_program.aleo/mint_record(0field);
+        assert_eq(r.x, 0field);
+    }
+```
+
+
+
 ## Using interpreted tests for modelling on-chain state
 While the testing framework cannot access on-chain state from Testnet or Mainnet, developers can simulate on-chain state using interpreted tests.  Within interpreted tests, developers are able to await Futures and update mappings.  Interpreted tests are annotated with the `script` keyword.
 
@@ -78,12 +90,15 @@ script test_async() {
 }
 ```
 
+:::info
+While non-async logic may be tested using an interpreted tests, all async functionality must be tested within interpreted tests.
+:::
+
+## Running tests
+Invoking the `leo test` command will run all of the compiled and interpreted tests. Developer may optionally select individual tests by supplying the function test name to the `leo test` command.
 
 
 
 
-
-On-chain state is not accessible.
-Test file name should match the program name of the test.
 Need at least one transition function in the test file.
 

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -35,28 +35,28 @@ The `example_program.leo` program contains a transition function which returns t
 
 ```Leo
 transition simple_addition(public a: u32, b: u32) -> u32 {
-        let c: u32 = a + b;
-        return c;
-    }
+    let c: u32 = a + b;
+    return c;
+}
 ```
 
 In the `test_example_program.leo`, we can write two tests to ensure that the transition logic returns correct values.
 ```Leo
 @test
-    transition test_simple_addition() {
-        let result: u32 = example_program.aleo/simple_addition(2u32, 3u32);
-        assert_eq(result, 5u32);
-    }
+transition test_simple_addition() {
+    let result: u32 = example_program.aleo/simple_addition(2u32, 3u32);
+    assert_eq(result, 5u32);
+}
 ```
 
 The `@should_fail` annotation should be added after the `@test` annotation for tests that are expected to fail.
 ```Leo
 @test
 @should_fail
-    transition test_simple_addition_fail() {
-        let result: u32 = example_program.aleo/simple_addition(2u32, 3u32);
-        assert_eq(result, 3u32);
-    }
+transition test_simple_addition_fail() {
+    let result: u32 = example_program.aleo/simple_addition(2u32, 3u32);
+    assert_eq(result, 3u32);
+}
 ```
 
 Developers can test that Record and struct fields match their expected values.
@@ -64,9 +64,9 @@ Developers can test that Record and struct fields match their expected values.
 ```Leo
 @test
 transition test_record_maker() {
-        let r: example_program.aleo/Example = example_program.aleo/mint_record(0field);
-        assert_eq(r.x, 0field);
-    }
+    let r: example_program.aleo/Example = example_program.aleo/mint_record(0field);
+    assert_eq(r.x, 0field);
+}
 ```
 
 :::info
@@ -78,6 +78,7 @@ Each test file is required to have at least one transition function.
 While the testing framework cannot access on-chain state from Testnet or Mainnet, developers can simulate on-chain state using interpreted tests.  Within interpreted tests, developers are able to await Futures and update mappings.  Interpreted tests are annotated with the `script` keyword.
 
 ```Leo
+@test
 script test_async() {
     const VAL: field = 12field;
     let fut: Future = example_program.aleo/set_mapping(VAL);

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -5,7 +5,7 @@ sidebar_label: Testing
 ---
 
 ## Introduction
-The Leo testing frameworks enables developers to validate their Leo program logic by writing unit and integration tests. Tests are written in Leo and are located in a `/tests` subdirectory of the main Leo project directory.
+The Leo testing frameworks enables developers to validate their Leo program logic by writing unit and integration tests. Tests are written in Leo and are located in a `tests/` subdirectory of the main Leo project directory.
 
 ```bash
 example_program

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -94,7 +94,7 @@ script test_async() {
 ```
 
 :::info
-While non-async logic may be tested using an interpreted tests, all async functionality must be tested within interpreted tests.
+External transitions -- async or not -- may be called from native or interpreted tests, but external async functions may only be called directly from interpreted tests.
 :::
 
 

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -30,7 +30,9 @@ Developers can add multiple `leo` files to the test directory but must ensure th
 :::
 
 
-## Testing transition function logic.
+## Testing transition functions.
+
+### Function logic
 
 The `example_program.leo` program contains a transition function which returns the sum of two `u32` inputs.
 
@@ -60,7 +62,25 @@ transition test_simple_addition_fail() {
 }
 ```
 
-Developers can test that Record and struct fields match their expected values.
+## Leo types
+
+Developers can test that Record and struct fields match their expected values.  In `example_program.leo`, a Record is minted transition function shown here:
+
+```Leo
+record Example {
+    owner: address,
+    x: field,
+}
+
+transition mint_record(x: field) -> Example {
+    return Example {
+        owner: self.signer,
+        x,
+    };
+}
+```
+
+The corresponding test in `test_example_program.leo` checks that the Record field contains the correct value:
 
 ```Leo
 @test

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -5,7 +5,7 @@ sidebar_label: Testing
 ---
 
 ## Introduction
-The Leo testing frameworks enables developers to validate their Leo program logic by writing unit and integration tests in Leo. Tests are written in a `/tests` subdirectory of the main Leo project directory.
+The Leo testing frameworks enables developers to validate their Leo program logic by writing unit and integration tests. Tests are written in Leo and are located in a `/tests` subdirectory of the main Leo project directory.
 
 ```bash
 ├── build
@@ -22,7 +22,7 @@ The Leo testing frameworks enables developers to validate their Leo program logi
 ```
 The test file is a Leo program that imports the program in `main.leo`.  The test functions will all be annotated with `@test` above the the function declaration. 
 
-This tutorial will use an example program which can be found in the [example's repository]().  
+This tutorial will use an example program which can be found in the [example's repository](https://github.com/ProvableHQ/leo-examples/tree/main/tests).  
 
 :::info
 The name of the test file must match the program name.  For example, if the name of the test file is `test_example_program.leo`, the program name should be `test_example_program.aleo`.
@@ -31,7 +31,7 @@ The name of the test file must match the program name.  For example, if the name
 
 ## Testing transition function logic.
 
-The `example_program.leo` program contains a transition function which adds two `u32` values and returns the sum.
+The `example_program.leo` program contains a transition function which returns the sum of two `u32` inputs.  When testing 
 
 ```Leo
 transition simple_addition(public a: u32, b: u32) -> u32 {
@@ -40,10 +40,50 @@ transition simple_addition(public a: u32, b: u32) -> u32 {
     }
 ```
 
+In the `test_example_program.leo`, we can write two tests to ensure that the transition logic returns correct values.
+```Leo
+@test
+    transition test_simple_addition() {
+        let result: u32 = example_program.aleo/simple_addition(2u32, 3u32);
+        assert_eq(result, 5u32);
+    }
+```
+
+The `@should_fail` annotation should be added after the `@test` annotation for tests that are expected to fail.
+```Leo
+@test
+@should_fail
+    transition test_simple_addition_fail() {
+        let result: u32 = example_program.aleo/simple_addition(2u32, 3u32);
+        assert_eq(result, 3u32);
+    }
+```
+
+## Using interpreted tests for modelling on-chain state
+While the testing framework cannot access on-chain state from Testnet or Mainnet, developers can simulate on-chain state using interpreted tests.  Within interpreted tests, developers are able to await Futures and update mappings.  Interpreted tests are annotated with the `script` keyword.
+
+```Leo
+script test_async() {
+    const VAL: field = 12field;
+    let fut: Future = example_program.aleo/set_mapping(VAL);
+    // We must await this future for the async code to run.
+    fut.await();
+    assert_eq(Mapping::get(example_program.aleo/map, 0field), VAL);
+
+    // scripts can also do other things normally only async code can do:
+    let rand_val: field = ChaCha::rand_field();
+    Mapping::set(example_program.aleo/map, VAL, rand_val);
+    let value: field = Mapping::get(example_program.aleo/map, VAL);
+    assert_eq(value, rand_val);
+}
+```
+
+
 
 
 
 
 On-chain state is not accessible.
 Test file name should match the program name of the test.
+Need at least one transition function in the test file.
 

--- a/documentation/testing/01_test_framework.md
+++ b/documentation/testing/01_test_framework.md
@@ -4,6 +4,46 @@ title: Leo's Native Testing Framework
 sidebar_label: Testing
 ---
 
-<!--TODO:-->
+## Introduction
+The Leo testing frameworks enables developers to validate their Leo program logic by writing unit and integration tests in Leo. Tests are written in a `/tests` subdirectory of the main Leo project directory.
 
-Coming soon!
+```bash
+├── build
+│   ├── imports
+│   │   └── test_example_program.aleo
+│   ├── main.aleo
+│   └── program.json
+├── outputs
+├── src
+│   └── main.leo
+├── tests
+│   └── test_example_program.leo
+└── program.json
+```
+The test file is a Leo program that imports the program in `main.leo`.  The test functions will all be annotated with `@test` above the the function declaration. 
+
+This tutorial will use an example program which can be found in the [example's repository]().  
+
+:::info
+The name of the test file must match the program name.  For example, if the name of the test file is `test_example_program.leo`, the program name should be `test_example_program.aleo`.
+:::
+
+
+## Testing transition function logic.
+
+The `example_program.leo` program contains a transition function which adds two `u32` values and returns the sum.
+
+```Leo
+transition simple_addition(public a: u32, b: u32) -> u32 {
+        let c: u32 = a + b;
+        return c;
+    }
+```
+
+
+
+
+
+On-chain state is not accessible.
+Test file name should match the program name of the test.
+


### PR DESCRIPTION
This PR adds documentation of the Leo native testing framework.  It should be reviewed (and merged) together with https://github.com/ProvableHQ/leo-examples/pull/8.