### PR TITLE
Added clarifying comments for --twice flag usage

### DIFF
--- a/documentation/cli/00_overview.md
+++ b/documentation/cli/00_overview.md
@@ -137,9 +137,13 @@ Use this command to deploy a program to the Aleo network. This requires having a
 
 To deploy the project in the current working directory.
 ```bash
-leo deploy // Defaults to using key information in `.env`, and deploys to `testnet3` via endoint `http://api.explorer.provable.com/v1`.
+leo deploy // Defaults to using key information in `.env`, and deploys to `testnet3` via endpoint `http://api.explorer.provable.com/v1`.
 leo deploy --endpoint "{$ENDPOINT}" --private-key "{$PRIVATE_KEY}" // To deploy using custom private key, to a custom endpoint (e.g. local devnet `http://0.0.0.0:3030`).
 ```
+
+:::info
+Note that until the release of SnarkOS v4.1.0, users will need to use a `--twice` when deploying to local devnets.
+:::
 
 See [Deploy](01_deploying.md) for more details.
 

--- a/documentation/cli/01_deploying.md
+++ b/documentation/cli/01_deploying.md
@@ -7,6 +7,8 @@ sidebar_label: Deploy
 
 The `leo deploy` command is used for deploying Leo program to a local devnet, Testnet, or Mainnet.
 
+Note that until the release of SnarkOS version 4.1.0, users will need to add a `--twice` flag to `leo deploy` when deploying programs to a local devnet.  This ensures that the correct program version is assigned to the program.  Once program upgradability is fully merged, this will no longer be a requirement. 
+
 The following parameters need to be specified in either a `.env` file or as environment variables: the target network, the Private Key, and a node API endpoint.
 
 An `.env` file should be formatted as follows:


### PR DESCRIPTION
This PR adds some clarifying comments on when users should use the `leo deploy --twice` command for local development.